### PR TITLE
feat: RN의 새로운 스크린으로 웹뷰 띄우는 브릿지 구현

### DIFF
--- a/src/utils/react-native-webview-bridge/new-webview/index.ts
+++ b/src/utils/react-native-webview-bridge/new-webview/index.ts
@@ -1,0 +1,21 @@
+import { NewWebViewData } from '@/utils/react-native-webview-bridge/types/newWebView.type'
+import { EMessageType, MessageData } from '../types/common.type'
+import webBridge from '@/utils/react-native-webview-bridge'
+
+function open(data: MessageData<NewWebViewData>) {
+  if (window?.ReactNativeWebView) {
+    webBridge.sendMessage(EMessageType.OPEN_NEW_WEBVIEW, data)
+  }
+}
+
+function close(data: MessageData) {
+  if (window?.ReactNativeWebView) {
+    webBridge.sendMessage(EMessageType.CLOSE_NEW_WEBVIEW, data)
+  }
+}
+
+const RNNewWebView = {
+  open,
+  close,
+}
+export default RNNewWebView

--- a/src/utils/react-native-webview-bridge/new-webview/rnWebViewBridge.ts
+++ b/src/utils/react-native-webview-bridge/new-webview/rnWebViewBridge.ts
@@ -3,16 +3,15 @@ import RNNewWebView from '@/utils/react-native-webview-bridge/new-webview'
 import webBridge from '@/utils/react-native-webview-bridge'
 import { NewWebViewData } from '../types/newWebView.type'
 
-type Functions = {
+type ReturnType = {
   open: (data: NewWebViewData, callbacks?: RNCallBacks) => void
   close: () => void
 }
-type ReturnType = [Functions['open'], Functions['close']]
 
-export default function rnWebViewBridge(key: string): ReturnType {
-  const thisKey = `NEW_WEBVIEW_${key}`
+function rnWebViewBridge(): ReturnType {
+  const thisKey = `NEW_WEBVIEW`
 
-  const open: Functions['open'] = (data, callbacks) => {
+  const open: ReturnType['open'] = (data, callbacks) => {
     if (callbacks) {
       webBridge.subscribe(thisKey, callbacks)
     }
@@ -23,9 +22,11 @@ export default function rnWebViewBridge(key: string): ReturnType {
     })
   }
 
-  const close: Functions['close'] = () => {
+  const close: ReturnType['close'] = () => {
     RNNewWebView.close({ eventKey: thisKey })
   }
 
-  return [open, close]
+  return { open, close }
 }
+
+export default rnWebViewBridge()

--- a/src/utils/react-native-webview-bridge/new-webview/rnWebViewBridge.ts
+++ b/src/utils/react-native-webview-bridge/new-webview/rnWebViewBridge.ts
@@ -1,0 +1,31 @@
+import { RNCallBacks } from '@/utils/react-native-webview-bridge/types/newWebView.type'
+import RNNewWebView from '@/utils/react-native-webview-bridge/new-webview'
+import webBridge from '@/utils/react-native-webview-bridge'
+import { NewWebViewData } from '../types/newWebView.type'
+
+type Functions = {
+  open: (data: NewWebViewData, callbacks?: RNCallBacks) => void
+  close: () => void
+}
+type ReturnType = [Functions['open'], Functions['close']]
+
+export default function rnWebViewBridge(key: string): ReturnType {
+  const thisKey = `NEW_WEBVIEW_${key}`
+
+  const open: Functions['open'] = (data, callbacks) => {
+    if (callbacks) {
+      webBridge.subscribe(thisKey, callbacks)
+    }
+
+    RNNewWebView.open({
+      eventKey: thisKey,
+      contents: data,
+    })
+  }
+
+  const close: Functions['close'] = () => {
+    RNNewWebView.close({ eventKey: thisKey })
+  }
+
+  return [open, close]
+}

--- a/src/utils/react-native-webview-bridge/types/common.type.ts
+++ b/src/utils/react-native-webview-bridge/types/common.type.ts
@@ -4,6 +4,8 @@
 export enum EMessageType {
   OPEN_BOTTOM_SHEET = 'OPEN_BOTTOM_SHEET',
   CLOSE_BOTTOM_SHEET = 'CLOSE_BOTTOM_SHEET',
+  OPEN_NEW_WEBVIEW = 'OPEN_NEW_WEBVIEW',
+  CLOSE_NEW_WEBVIEW = 'CLOSE_NEW_WEBVIEW',
 }
 export type MessageType = keyof typeof EMessageType
 export type MessageData<T = Record<string | number, unknown>> = {

--- a/src/utils/react-native-webview-bridge/types/newWebView.type.ts
+++ b/src/utils/react-native-webview-bridge/types/newWebView.type.ts
@@ -1,0 +1,19 @@
+export type Key = string
+
+export type NewWebViewData = {
+  key: Key
+  url: string
+}
+
+export enum RN_EVENT_TYPE {
+  CLOSE = 'CLOSE',
+  OPENED = 'OPENED',
+}
+export type RNEventType = keyof typeof RN_EVENT_TYPE
+
+/**
+ * @description RN에 정의되어 있는 콜백 함수입니다.
+ */
+export type RNCallBacks = {
+  onClose?: () => void
+}


### PR DESCRIPTION
## 🔖 작업 내용 (Summary)
* [최근 2 커밋](https://github.com/dnd-side-project/dnd-8th-7-frontend/pull/21/files/120bb90570b0f40651e27c96bf14632392cfd437..d6d8bfa3ec52be6dd05e39f680926668bb81493e)만 봐주시면 됩니다.
* [app 작업](https://github.com/dnd-side-project/dnd-8th-7-frontend-app/pull/18) 도 함께 보시면 좋습니다.

### 사용방법
```ts
import rnWebViewBridge from '@/utils/react-native-webview-bridge/new-webview/rnWebViewBridge'

  const handleNewBlockClick = () => {
    rnWebViewBridge.open({
      key: 'newBlock',
      url: 'http://localhost:3000/blocks/new',
    })
  }

  const handleClose = () => {
    rnWebViewBridge.close()
  }
```

`rnWebViewBridge`의 `open`, `close` 메소드를 사용하실 수 있습니다.


## 기타 사항 (Etc)

<img src="https://user-images.githubusercontent.com/49540564/219941992-636d0abc-3617-45e3-96f8-b4b109bc5da0.gif" width="300" />