### PR TITLE
feat: 블럭 메인 페이지 

### DIFF
--- a/src/components/Block/index.stories.tsx
+++ b/src/components/Block/index.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import Block from '@/components/Block'
-import type { Block as BlockType } from '@/types/block'
+import type { BlockDetail } from '@/types/block'
 
 export default {
   title: 'components/Block',
@@ -9,7 +9,8 @@ export default {
 
 const Template: ComponentStory<typeof Block> = (args) => <Block {...args} />
 
-const MOCK_DATA: BlockType = {
+const MOCK_DATA: BlockDetail = {
+  blockId: 1,
   color: '#FF7154',
   icon: '😂',
   title: '출근 준비',

--- a/src/components/Block/index.stories.tsx
+++ b/src/components/Block/index.stories.tsx
@@ -12,7 +12,7 @@ const Template: ComponentStory<typeof Block> = (args) => <Block {...args} />
 const MOCK_DATA: BlockType = {
   color: '#FF7154',
   icon: '😂',
-  blockTitle: '출근 준비',
+  title: '출근 준비',
   sumOfTask: 4,
   sumOfDoneTask: 2,
   tasks: [
@@ -39,13 +39,13 @@ const MOCK_DATA: BlockType = {
   ],
 }
 
-const { color, icon, blockTitle, sumOfTask, sumOfDoneTask, tasks } = MOCK_DATA
+const { color, icon, title, sumOfTask, sumOfDoneTask, tasks } = MOCK_DATA
 
 export const Basic = Template.bind({})
 Basic.args = {
   color,
   icon,
-  blockTitle,
+  title,
   sumOfTask,
   sumOfDoneTask,
   tasks,

--- a/src/components/Block/index.tsx
+++ b/src/components/Block/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { LockIcon, MoreVerticalIcon } from '@/components/Icons'
-import { Block } from '@/types/block'
+import type { Block as BlockType } from '@/types/block'
 import useRNListBottomSheet from '@/utils/react-native-webview-bridge/bottom-sheet/useRNListBottomSheet'
 import webBridge from '@/utils/react-native-webview-bridge'
 import AddTaskButton from './AddTaskButton'
@@ -27,15 +27,15 @@ const BlockIcon = ({ icon }: { icon: string }) => {
   )
 }
 
-const TodoBlock = ({
+const Block = ({
   color,
   icon,
-  blockTitle,
+  title,
   sumOfTask,
   sumOfDoneTask,
   tasks,
   locked = false,
-}: Block & { locked?: boolean }) => {
+}: BlockType & { locked?: boolean }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [open] = useRNListBottomSheet('blockMenu')
 
@@ -47,7 +47,7 @@ const TodoBlock = ({
     e.stopPropagation()
     if (locked) return
     open({
-      title: blockTitle,
+      title,
       items: [
         { key: 'edit', title: '수정하기' },
         { key: 'delete', title: '삭제하기' },
@@ -89,7 +89,7 @@ const TodoBlock = ({
               <p className="ml-2.5">{LOCKED_TEXT}</p>
             </div>
           ) : (
-            <p>{blockTitle}</p>
+            <p>{title}</p>
           )}
 
           <p className="font-medium">
@@ -118,4 +118,4 @@ const TodoBlock = ({
   )
 }
 
-export default TodoBlock
+export default Block

--- a/src/components/Block/index.tsx
+++ b/src/components/Block/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { LockIcon, MoreVerticalIcon } from '@/components/Icons'
-import type { Block as BlockType } from '@/types/block'
+import type { BlockDetail } from '@/types/block'
 import useRNListBottomSheet from '@/utils/react-native-webview-bridge/bottom-sheet/useRNListBottomSheet'
 import webBridge from '@/utils/react-native-webview-bridge'
 import AddTaskButton from './AddTaskButton'
@@ -28,6 +28,7 @@ const BlockIcon = ({ icon }: { icon: string }) => {
 }
 
 const Block = ({
+  blockId,
   color,
   icon,
   title,
@@ -35,7 +36,7 @@ const Block = ({
   sumOfDoneTask,
   tasks,
   locked = false,
-}: BlockType & { locked?: boolean }) => {
+}: BlockDetail & { locked?: boolean }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [open] = useRNListBottomSheet('blockMenu')
 
@@ -69,6 +70,7 @@ const Block = ({
 
   return (
     <div
+      key={blockId}
       className={clsx(
         'flex',
         'flex-col',

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -40,4 +40,5 @@ Basic.args = {
   color: 'black',
   fontWeight: 'medium',
   rounded: 'md',
+  outlined: false,
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -17,6 +17,7 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   fontWeight?: FontWeight
   rounded?: Rounded
   disabled?: boolean
+  outlined?: boolean
 }
 
 const SIZE_CONFIG: SizeConfig = {
@@ -50,6 +51,7 @@ const Button = ({
   size = 'md',
   rounded = 'md',
   fontWeight = 'medium',
+  outlined = false,
   className,
   ...rest
 }: PropsWithChildren<ButtonProps>) => {
@@ -72,6 +74,9 @@ const Button = ({
         className,
         {
           'disabled:text-textGray-50 disabled:bg-gray-100': color === 'black',
+        },
+        {
+          'border border-gray-400': outlined,
         },
       )}
     >

--- a/src/constants/block.ts
+++ b/src/constants/block.ts
@@ -1,37 +1,6 @@
-import { Block, BlockList } from '@/types/block'
+import { BlockList } from '@/types/block'
 
 export const DAYS = ['일', '월', '화', '수', '목', '금', '토']
-
-// mock data - 추후 제거 예정
-const MOCK_BLOCK: Block = {
-  color: '#FF7154',
-  icon: '',
-  title: '출근 준비',
-  sumOfTask: 4,
-  sumOfDoneTask: 2,
-  tasks: [
-    {
-      taskId: 1,
-      task: '할 일 1',
-      isDone: false,
-    },
-    {
-      taskId: 2,
-      task: '할 일 2',
-      isDone: true,
-    },
-    {
-      taskId: 3,
-      task: '할 일 3',
-      isDone: true,
-    },
-    {
-      taskId: 4,
-      task: '할 일 3',
-      isDone: false,
-    },
-  ],
-}
 
 export const MOCK_BLOCK_LIST: BlockList = {
   date: '2022-01-25',
@@ -85,30 +54,30 @@ export const MOCK_COLORS: string[] = [
 export const MOCK_WEEKLY_BLOCKS = [
   {
     date: '2022-01-23',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
   {
     date: '2022-01-24',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
   {
     date: '2022-01-25',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
   {
     date: '2022-01-26',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
   {
     date: '2022-01-27',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
   {
     date: '2022-01-28',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
   {
     date: '2022-01-29',
-    colors: MOCK_COLORS,
+    color: MOCK_COLORS,
   },
 ]

--- a/src/constants/block.ts
+++ b/src/constants/block.ts
@@ -1,10 +1,12 @@
-import { Block } from '@/types/block'
+import { Block, BlockList } from '@/types/block'
+
+export const DAYS = ['일', '월', '화', '수', '목', '금', '토']
 
 // mock data - 추후 제거 예정
 const MOCK_BLOCK: Block = {
   color: '#FF7154',
   icon: '',
-  blockTitle: '출근 준비',
+  title: '출근 준비',
   sumOfTask: 4,
   sumOfDoneTask: 2,
   tasks: [
@@ -31,24 +33,46 @@ const MOCK_BLOCK: Block = {
   ],
 }
 
-export const MOCK_BLOCK_LIST: Block[] = [
-  MOCK_BLOCK,
-  {
-    ...MOCK_BLOCK,
-    color: '#FFB673',
-    blockTitle: '회사',
-  },
-  {
-    ...MOCK_BLOCK,
-    color: '#7E85FF',
-    blockTitle: '디앤디',
-  },
-  {
-    ...MOCK_BLOCK,
-    color: '#5B9DFF',
-    blockTitle: '휴식',
-  },
-]
+export const MOCK_BLOCK_LIST: BlockList = {
+  date: '2022-01-25',
+  totalBlock: 2,
+  totalTask: 3,
+  blocks: [
+    {
+      color: '#FF7154',
+      icon: '😀',
+      title: '제목1',
+      sumOfTask: 2,
+      sumOfDoneTask: 1,
+      tasks: [
+        {
+          taskId: 1,
+          task: 'content',
+          isDone: true,
+        },
+        {
+          taskId: 2,
+          task: 'content2',
+          isDone: false,
+        },
+      ],
+    },
+    {
+      color: '#7E85FF',
+      icon: '🥲',
+      title: '제목2',
+      sumOfTask: 1,
+      sumOfDoneTask: 1,
+      tasks: [
+        {
+          taskId: 3,
+          task: 'content3',
+          isDone: true,
+        },
+      ],
+    },
+  ],
+}
 
 export const MOCK_COLORS: string[] = [
   '#FF7154',
@@ -57,8 +81,6 @@ export const MOCK_COLORS: string[] = [
   '#5B9DFF',
   '#7E85FF',
 ]
-
-export const DAYS = ['일', '월', '화', '수', '목', '금', '토']
 
 export const MOCK_WEEKLY_BLOCKS = [
   {

--- a/src/constants/block.ts
+++ b/src/constants/block.ts
@@ -8,6 +8,7 @@ export const MOCK_BLOCK_LIST: BlockList = {
   totalTask: 3,
   blocks: [
     {
+      blockId: 1,
       color: '#FF7154',
       icon: '😀',
       title: '제목1',
@@ -27,6 +28,7 @@ export const MOCK_BLOCK_LIST: BlockList = {
       ],
     },
     {
+      blockId: 2,
       color: '#7E85FF',
       icon: '🥲',
       title: '제목2',

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.NEXT_PUBLIC_APP_URL

--- a/src/containers/Home/BlockList/DiaryButton.tsx
+++ b/src/containers/Home/BlockList/DiaryButton.tsx
@@ -1,15 +1,22 @@
 import Button from '@/components/Button'
 import { EditIcon } from '@/components/Icons'
 
+import rnWebViewBridge from '@/utils/react-native-webview-bridge/new-webview/rnWebViewBridge'
+
 const DiaryButton = () => {
-  const handleDiaryCreate = () => {}
+  const handleDiaryCreate = () => {
+    rnWebViewBridge.open({
+      key: 'dailyDiary',
+      url: 'http://localhost:3000/dailyDiary',
+    })
+  }
 
   return (
     <Button
       outlined
       rounded="sm"
       color="white"
-      className="text-textGray-200 py-1.5 !px-3 w-fit"
+      className="text-textGray-200 py-1.5 !px-3 !w-fit"
       onClick={handleDiaryCreate}
     >
       <EditIcon className="!fill-textGray-200 mr-1" width={14} height={14} />

--- a/src/containers/Home/BlockList/DiaryButton.tsx
+++ b/src/containers/Home/BlockList/DiaryButton.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/Button'
 import { EditIcon } from '@/components/Icons'
+import { BASE_URL } from '@/constants/urls'
 
 import rnWebViewBridge from '@/utils/react-native-webview-bridge/new-webview/rnWebViewBridge'
 
@@ -7,7 +8,7 @@ const DiaryButton = () => {
   const handleDiaryCreate = () => {
     rnWebViewBridge.open({
       key: 'dailyDiary',
-      url: 'http://localhost:3000/dailyDiary',
+      url: `${BASE_URL}/dailyDiary`,
     })
   }
 

--- a/src/containers/Home/BlockList/DiaryButton.tsx
+++ b/src/containers/Home/BlockList/DiaryButton.tsx
@@ -1,0 +1,21 @@
+import Button from '@/components/Button'
+import { EditIcon } from '@/components/Icons'
+
+const DiaryButton = () => {
+  const handleDiaryCreate = () => {}
+
+  return (
+    <Button
+      outlined
+      rounded="sm"
+      color="white"
+      className="text-textGray-200 py-1.5 !px-3 w-fit"
+      onClick={handleDiaryCreate}
+    >
+      <EditIcon className="!fill-textGray-200 mr-1" width={14} height={14} />
+      하루 일기
+    </Button>
+  )
+}
+
+export default DiaryButton

--- a/src/containers/Home/BlockList/index.tsx
+++ b/src/containers/Home/BlockList/index.tsx
@@ -1,0 +1,59 @@
+import Button from '@/components/Button'
+import Date from '@/components/Date'
+import { AddIcon } from '@/components/Icons'
+import Block from '@/components/Block'
+import NoData from '@/components/NoData'
+import { MOCK_BLOCK_LIST } from '@/constants/block'
+import useSelectedDateState from '@/store/selectedDate'
+import DiaryButton from './DiaryButton'
+
+const BlockList = () => {
+  const selectedDate = useSelectedDateState((state) => state.date) // TODO: 해당 날짜의 api 불러올 것
+  const { date, totalBlock, totalTask, blocks } = MOCK_BLOCK_LIST
+
+  const handleBlockCreate = () => {
+    // 블럭 생성 페이지로 이동
+  }
+
+  return (
+    <>
+      <div className="flex items-end justify-between">
+        <Date date={date} totalBlock={totalBlock} totalTask={totalTask} />
+        <DiaryButton />
+      </div>
+
+      <div className="mt-[18px] mb-5">
+        {blocks.length === 0 ? (
+          <>
+            <NoData outlined />
+            <Button
+              rounded="lg"
+              className="!py-[15px] mt-5"
+              onClick={handleBlockCreate}
+            >
+              <AddIcon width={18} height={18} className="!fill-white" />
+              <p className="ml-px">새 블럭 만들기</p>
+            </Button>
+          </>
+        ) : (
+          blocks.map(
+            ({ color, icon, title, sumOfTask, sumOfDoneTask, tasks }, idx) => (
+              <div key={idx} className="mb-2">
+                <Block
+                  color={color}
+                  icon={icon}
+                  title={title}
+                  sumOfTask={sumOfTask}
+                  sumOfDoneTask={sumOfDoneTask}
+                  tasks={tasks}
+                />
+              </div>
+            ),
+          )
+        )}
+      </div>
+    </>
+  )
+}
+
+export default BlockList

--- a/src/containers/Home/BlockList/index.tsx
+++ b/src/containers/Home/BlockList/index.tsx
@@ -37,9 +37,13 @@ const BlockList = () => {
           </>
         ) : (
           blocks.map(
-            ({ color, icon, title, sumOfTask, sumOfDoneTask, tasks }, idx) => (
+            (
+              { blockId, color, icon, title, sumOfTask, sumOfDoneTask, tasks },
+              idx,
+            ) => (
               <div key={idx} className="mb-2">
                 <Block
+                  blockId={blockId}
                   color={color}
                   icon={icon}
                   title={title}

--- a/src/containers/Home/CalendarPanel/index.tsx
+++ b/src/containers/Home/CalendarPanel/index.tsx
@@ -1,5 +1,9 @@
 const CalendarPanel = () => {
-  return <div>calendar panel</div>
+  return (
+    <div className="w-full h-52 flex items-center justify-center">
+      calendar 준비중입니다
+    </div>
+  )
 }
 
 export default CalendarPanel

--- a/src/containers/Home/DailyBlockPanel/WeeklyBlocks.tsx
+++ b/src/containers/Home/DailyBlockPanel/WeeklyBlocks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import dayjs from 'dayjs'
 import clsx from 'clsx'
 import DailyBlock from '@/components/DailyBlock'
@@ -66,7 +66,7 @@ const DailyBlockPanel = ({
 
   return (
     <div className="flex justify-between mx-auto my-7 min-w-80 max-w-[400px]">
-      {weeklyBlocks.map(({ date: dateTime, colors }, idx) => {
+      {weeklyBlocks.map(({ date: dateTime, color }, idx) => {
         const formattedDate = dayjs(dateTime).format('YYYY-MM-DD')
         const day = dayjs(dateTime).day()
         const date = dayjs(dateTime).date()
@@ -75,7 +75,7 @@ const DailyBlockPanel = ({
           <div key={idx} className="flex flex-col items-center text-base">
             <p className="text-textGray-50 mb-[5px]">{DAYS[day % 7]}</p>
             <DayBlock
-              colors={colors}
+              colors={color}
               date={date}
               isActive={activeBlockIdx === idx}
               onClick={() => handleBlockClick(formattedDate, idx)}

--- a/src/containers/Home/DailyBlockPanel/WeeklyBlocks.tsx
+++ b/src/containers/Home/DailyBlockPanel/WeeklyBlocks.tsx
@@ -1,16 +1,22 @@
+import { useEffect, useState } from 'react'
 import dayjs from 'dayjs'
 import clsx from 'clsx'
 import DailyBlock from '@/components/DailyBlock'
-import { DAYS, MOCK_WEEKLY_BLOCKS } from '@/constants/block'
+import { DAYS } from '@/constants/block'
+import type { DailyBlock as DailyBlockType } from '@/types/block'
+import { noop } from '@/utils'
+import useSelectedDateState from '@/store/selectedDate'
 
 const DayBlock = ({
   colors,
   date,
-  isToday,
+  isActive,
+  onClick = noop,
 }: {
   colors: string[]
   date: number
-  isToday: boolean
+  isActive: boolean
+  onClick?: () => void
 }) => {
   return (
     <>
@@ -23,12 +29,19 @@ const DayBlock = ({
           'pb-1',
           'px-1.5',
           'rounded-[11px]',
-          { border: isToday },
+          'cursor-pointer',
+          'border',
+          'border-white',
+          { 'border-gray-300': isActive },
         )}
+        onClick={onClick}
       >
         <DailyBlock colors={colors} />
         <p
-          className={clsx('mt-1', isToday ? 'text-black' : 'text-textGray-100')}
+          className={clsx(
+            'mt-1',
+            isActive ? 'text-black' : 'text-textGray-100',
+          )}
         >
           {date}
         </p>
@@ -37,18 +50,36 @@ const DayBlock = ({
   )
 }
 
-const WeeklyBlocks = () => {
-  const today = dayjs().day()
+const DailyBlockPanel = ({
+  weeklyBlocks,
+}: {
+  weeklyBlocks: DailyBlockType[]
+}) => {
+  const todayIdx = dayjs().day() % 7
+  const [activeBlockIdx, setActiveBlockIdx] = useState(todayIdx)
+  const setSelectedDate = useSelectedDateState((state) => state.setSelectedDate)
+
+  const handleBlockClick = (formattedDate: string, idx: number) => {
+    setSelectedDate(formattedDate)
+    setActiveBlockIdx(idx)
+  }
 
   return (
-    <div className="flex justify-between mx-auto mb-7 min-w-80 max-w-[400px]">
-      {MOCK_WEEKLY_BLOCKS.map(({ date: dateTime, colors }, idx) => {
+    <div className="flex justify-between mx-auto my-7 min-w-80 max-w-[400px]">
+      {weeklyBlocks.map(({ date: dateTime, colors }, idx) => {
+        const formattedDate = dayjs(dateTime).format('YYYY-MM-DD')
         const day = dayjs(dateTime).day()
         const date = dayjs(dateTime).date()
+
         return (
           <div key={idx} className="flex flex-col items-center text-base">
             <p className="text-textGray-50 mb-[5px]">{DAYS[day % 7]}</p>
-            <DayBlock colors={colors} date={date} isToday={today === day} />
+            <DayBlock
+              colors={colors}
+              date={date}
+              isActive={activeBlockIdx === idx}
+              onClick={() => handleBlockClick(formattedDate, idx)}
+            />
           </div>
         )
       })}
@@ -56,4 +87,4 @@ const WeeklyBlocks = () => {
   )
 }
 
-export default WeeklyBlocks
+export default DailyBlockPanel

--- a/src/containers/Home/DailyBlockPanel/index.tsx
+++ b/src/containers/Home/DailyBlockPanel/index.tsx
@@ -1,54 +1,60 @@
+import { useEffect } from 'react'
+import dayjs from 'dayjs'
+import { MOCK_WEEKLY_BLOCKS } from '@/constants/block'
 import Button from '@/components/Button'
-import Date from '@/components/Date'
 import { AddIcon } from '@/components/Icons'
-import Block from '@/components/Block'
-import NoData from '@/components/NoData'
-import { MOCK_BLOCK_LIST, MOCK_WEEKLY_BLOCKS } from '@/constants/block'
+import useSelectedDateState from '@/store/selectedDate'
 import WeeklyBlocks from './WeeklyBlocks'
+import BlockList from '../BlockList'
+
+import rnWebViewBridge from '@/utils/react-native-webview-bridge/new-webview/rnWebViewBridge'
+
+const AddButton = ({
+  text,
+  onClick,
+}: {
+  text: string
+  onClick: () => void
+}) => {
+  return (
+    <Button
+      color="gray"
+      fontWeight="bold"
+      className="py-[11px]"
+      onClick={onClick}
+    >
+      <AddIcon className="!fill-textGray-200" width={18} height={18} />
+      {text}
+    </Button>
+  )
+}
 
 const DailyBlockPanel = () => {
-  const { date, totalBlock, totalTask, blocks } = MOCK_BLOCK_LIST
+  const setSelectedDate = useSelectedDateState((state) => state.setSelectedDate)
+  useEffect(() => {
+    const today = String(dayjs().format('YYYY-MM-DD'))
+    setSelectedDate(today)
+  }, [setSelectedDate])
 
-  const handleBlockCreate = () => {
-    // 블럭 생성 페이지로 이동
+  const handleAddSavedBlock = () => {} // TODO: 페이지 연결
+
+  const handleAddNewBlock = () => {
+    rnWebViewBridge.open({
+      key: 'newBlock',
+      url: 'http://localhost:3000/blocks/new',
+    })
   }
 
   return (
-    <div className="px-5 mt-7">
+    <div className="px-5">
       <WeeklyBlocks weeklyBlocks={MOCK_WEEKLY_BLOCKS} />
-      <Date date={date} totalBlock={totalBlock} totalTask={totalTask} />
-      <div className="mt-[18px] mb-5">
-        {blocks.length === 0 ? (
-          <>
-            <NoData outlined />
-            <Button
-              rounded="lg"
-              className="!py-[15px] mt-5"
-              onClick={handleBlockCreate}
-            >
-              <AddIcon width={18} height={18} className="!fill-white" />
-              <p className="ml-px">새 블럭 만들기</p>
-            </Button>
-          </>
-        ) : (
-          blocks.map(
-            ({ color, icon, title, sumOfTask, sumOfDoneTask, tasks }, idx) => (
-              <div key={idx} className="mb-2">
-                <Block
-                  color={color}
-                  icon={icon}
-                  title={title}
-                  sumOfTask={sumOfTask}
-                  sumOfDoneTask={sumOfDoneTask}
-                  tasks={tasks}
-                />
-              </div>
-            ),
-          )
-        )}
+      <BlockList />
+
+      <div className="flex gap-2">
+        <AddButton text="블럭 불러오기" onClick={handleAddSavedBlock} />
+        <AddButton text="새 블럭 만들기" onClick={handleAddNewBlock} />
       </div>
     </div>
   )
 }
-
 export default DailyBlockPanel

--- a/src/containers/Home/DailyBlockPanel/index.tsx
+++ b/src/containers/Home/DailyBlockPanel/index.tsx
@@ -2,44 +2,51 @@ import Button from '@/components/Button'
 import Date from '@/components/Date'
 import { AddIcon } from '@/components/Icons'
 import Block from '@/components/Block'
-import { MOCK_BLOCK_LIST } from '@/constants/block'
+import NoData from '@/components/NoData'
+import { MOCK_BLOCK_LIST, MOCK_WEEKLY_BLOCKS } from '@/constants/block'
 import WeeklyBlocks from './WeeklyBlocks'
 
-// TODO : 서버 데이터 연결
-const DATE = '2022-01-25'
-const TOTAL_BLOCK = 0
-const TOTAL_TASK = 0
-
 const DailyBlockPanel = () => {
+  const { date, totalBlock, totalTask, blocks } = MOCK_BLOCK_LIST
+
+  const handleBlockCreate = () => {
+    // 블럭 생성 페이지로 이동
+  }
+
   return (
     <div className="px-5 mt-7">
-      <WeeklyBlocks />
-      <Date date={DATE} totalBlock={TOTAL_BLOCK} totalTask={TOTAL_TASK} />
-      <div className="my-5">
-        {/* Data 없는 경우 처리 <NoData outlined /> */}
-        {MOCK_BLOCK_LIST.map(
-          (
-            { color, icon, blockTitle, sumOfTask, sumOfDoneTask, tasks },
-            idx,
-          ) => (
-            <div key={idx} className="mb-2">
-              <Block
-                color={color}
-                icon={icon}
-                blockTitle={blockTitle}
-                sumOfTask={sumOfTask}
-                sumOfDoneTask={sumOfDoneTask}
-                tasks={tasks}
-              />
-            </div>
-          ),
+      <WeeklyBlocks weeklyBlocks={MOCK_WEEKLY_BLOCKS} />
+      <Date date={date} totalBlock={totalBlock} totalTask={totalTask} />
+      <div className="mt-[18px] mb-5">
+        {blocks.length === 0 ? (
+          <>
+            <NoData outlined />
+            <Button
+              rounded="lg"
+              className="!py-[15px] mt-5"
+              onClick={handleBlockCreate}
+            >
+              <AddIcon width={18} height={18} className="!fill-white" />
+              <p className="ml-px">새 블럭 만들기</p>
+            </Button>
+          </>
+        ) : (
+          blocks.map(
+            ({ color, icon, title, sumOfTask, sumOfDoneTask, tasks }, idx) => (
+              <div key={idx} className="mb-2">
+                <Block
+                  color={color}
+                  icon={icon}
+                  title={title}
+                  sumOfTask={sumOfTask}
+                  sumOfDoneTask={sumOfDoneTask}
+                  tasks={tasks}
+                />
+              </div>
+            ),
+          )
         )}
       </div>
-
-      <Button rounded="lg" className="!py-[15px]">
-        <AddIcon width={18} height={18} className="fill-white" />
-        <p className="ml-px">새 블럭 만들기</p>
-      </Button>
     </div>
   )
 }

--- a/src/containers/Home/DailyBlockPanel/index.tsx
+++ b/src/containers/Home/DailyBlockPanel/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import dayjs from 'dayjs'
 import { MOCK_WEEKLY_BLOCKS } from '@/constants/block'
+import { BASE_URL } from '@/constants/urls'
 import Button from '@/components/Button'
 import { AddIcon } from '@/components/Icons'
 import useSelectedDateState from '@/store/selectedDate'
@@ -39,14 +40,14 @@ const DailyBlockPanel = () => {
   const handleAddSavedBlock = () => {
     rnWebViewBridge.open({
       key: 'savedBlock',
-      url: 'http://localhost:3000/blocks/saved',
+      url: `${BASE_URL}/blocks/saved`,
     })
   }
 
   const handleAddNewBlock = () => {
     rnWebViewBridge.open({
       key: 'newBlock',
-      url: 'http://localhost:3000/blocks/new',
+      url: `${BASE_URL}/blocks/new`,
     })
   }
 

--- a/src/containers/Home/DailyBlockPanel/index.tsx
+++ b/src/containers/Home/DailyBlockPanel/index.tsx
@@ -36,7 +36,12 @@ const DailyBlockPanel = () => {
     setSelectedDate(today)
   }, [setSelectedDate])
 
-  const handleAddSavedBlock = () => {} // TODO: 페이지 연결
+  const handleAddSavedBlock = () => {
+    rnWebViewBridge.open({
+      key: 'savedBlock',
+      url: 'http://localhost:3000/blocks/saved',
+    })
+  }
 
   const handleAddNewBlock = () => {
     rnWebViewBridge.open({

--- a/src/containers/NewBlock/index.tsx
+++ b/src/containers/NewBlock/index.tsx
@@ -9,6 +9,8 @@ import Switch from '@/components/Switch'
 import Header from '@/components/Header'
 import { BottomButtonLayout } from '@/components/Layout'
 
+import rnWebViewBridge from '@/utils/react-native-webview-bridge/new-webview/rnWebViewBridge'
+
 const TITLE =
   'text-lg font-bold tracking-[-0.004em] text-black mt-[30px] mb-[12px]'
 const SUB_TITLE = 'text-lg tracking-[-0.006em] text-black mb-[6px]'
@@ -41,7 +43,7 @@ export default function NewBlockContainer() {
   }
 
   const handleClose = () => {
-    console.log('closed')
+    rnWebViewBridge.close()
   }
 
   return (

--- a/src/containers/SavedBlock/SavedBlock/index.stories.tsx
+++ b/src/containers/SavedBlock/SavedBlock/index.stories.tsx
@@ -11,16 +11,16 @@ const Template: ComponentStory<typeof Block> = (args) => <Block {...args} />
 const MOCK_DATA = {
   color: '#FF7154',
   icon: '😂',
-  blockTitle: '출근 준비',
+  title: '출근 준비',
   sumOfTask: 4,
 }
 
-const { color, icon, blockTitle, sumOfTask } = MOCK_DATA
+const { color, icon, title, sumOfTask } = MOCK_DATA
 
 export const SavedBlock = Template.bind({})
 SavedBlock.args = {
   color,
   icon,
-  blockTitle,
+  title,
   sumOfTask,
 }

--- a/src/containers/SavedBlock/SavedBlock/index.tsx
+++ b/src/containers/SavedBlock/SavedBlock/index.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx'
 import { useEffect } from 'react'
 import { MoreVerticalIcon } from '@/components/Icons'
-import { Block as TodoBlock } from '@/types/block'
+import { BlockDetail } from '@/types/block'
 import useRNListBottomSheet from '@/utils/react-native-webview-bridge/bottom-sheet/useRNListBottomSheet'
 import webBridge from '@/utils/react-native-webview-bridge'
 
-type Block = Pick<TodoBlock, 'color' | 'icon' | 'blockTitle' | 'sumOfTask'>
+type Block = Pick<BlockDetail, 'color' | 'icon' | 'title' | 'sumOfTask'>
 
 const BlockIcon = ({ icon }: { icon: string }) => {
   return (
@@ -28,7 +28,7 @@ const BlockIcon = ({ icon }: { icon: string }) => {
 const SavedBlock = ({
   color,
   icon,
-  blockTitle,
+  title,
   sumOfTask,
 }: Block & { locked?: boolean }) => {
   const [open] = useRNListBottomSheet('blockMenu')
@@ -36,7 +36,7 @@ const SavedBlock = ({
   const handleMoreClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     e.stopPropagation()
     open({
-      title: blockTitle,
+      title,
       items: [{ key: 'delete', title: '삭제하기' }],
     })
   }
@@ -65,7 +65,7 @@ const SavedBlock = ({
         <BlockIcon icon={icon} />
 
         <div className="flex justify-between text-base font-bold ml-2.5 mr-2 w-[calc(100%_-_34px_-_24px)]">
-          <p>{blockTitle}</p>
+          <p>{title}</p>
           <p className="font-medium">{sumOfTask}</p>
         </div>
 

--- a/src/containers/SavedBlock/index.tsx
+++ b/src/containers/SavedBlock/index.tsx
@@ -9,6 +9,8 @@ import NoData from '@/components/NoData'
 import CheckBox from '@/components/CheckBox'
 import SavedBlock from './SavedBlock'
 
+import rnWebViewBridge from '@/utils/react-native-webview-bridge/new-webview/rnWebViewBridge'
+
 export default function SavedBlockContainer() {
   const checkedBlock = useRef(new Set()).current
   /**
@@ -26,9 +28,17 @@ export default function SavedBlockContainer() {
     }
   }
 
+  const handleBack = () => {
+    rnWebViewBridge.close()
+  }
+
   return (
     <BottomButtonLayout showButton={!!blocksLength} buttonText="완료">
-      <Header title="블럭 불러오기" leftButton="back" />
+      <Header
+        title="블럭 불러오기"
+        leftButton="back"
+        onLeftButtonClick={handleBack}
+      />
       <div className={clsx('pt-[56px]', 'px-[20px]', 'pb-[20px]', 'h-full')}>
         {blocksLength ? (
           <div

--- a/src/containers/SavedBlock/index.tsx
+++ b/src/containers/SavedBlock/index.tsx
@@ -62,7 +62,7 @@ export default function SavedBlockContainer() {
                 <SavedBlock
                   color={colors.red}
                   icon={'😂'}
-                  blockTitle={'한둘셋넷일여아열한둘셋'}
+                  title={'한둘셋넷일여아열한둘셋'}
                   sumOfTask={12}
                 />
               </div>

--- a/src/store/selectedDate.ts
+++ b/src/store/selectedDate.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+
+type State = {
+  date: string
+}
+
+type Actions = {
+  setSelectedDate: (date: string) => void
+}
+
+const useSelectedDateState = create<State & Actions>((set) => ({
+  date: '',
+  setSelectedDate: (selectedDate) => {
+    set(() => ({
+      date: selectedDate,
+    }))
+  },
+}))
+
+export default useSelectedDateState

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -1,15 +1,8 @@
-export type Block = {
-  color: string
-  icon: string
-  title: string
-  sumOfTask: number
-  sumOfDoneTask: number
-  tasks: Task[]
-}
 export type DailyBlock = {
   date: string
   color: Array<string>
 }
+
 export type BlockDetail = {
   blockId: number
   color: string
@@ -19,6 +12,7 @@ export type BlockDetail = {
   sumOfDoneTask: number
   tasks: Array<Task>
 }
+
 export type Task = {
   taskId: number
   task: string
@@ -29,5 +23,5 @@ export type BlockList = {
   date: string
   totalBlock: number
   totalTask: number
-  blocks: Block[]
+  blocks: BlockDetail[]
 }

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -1,8 +1,7 @@
-/** TODO BlockDetail 과 병합 */
 export type Block = {
-  color: string | string[]
+  color: string
   icon: string
-  blockTitle: string
+  title: string
   sumOfTask: number
   sumOfDoneTask: number
   tasks: Task[]
@@ -24,4 +23,11 @@ export type Task = {
   taskId: number
   task: string
   isDone: boolean
+}
+
+export type BlockList = {
+  date: string
+  totalBlock: number
+  totalTask: number
+  blocks: Block[]
 }


### PR DESCRIPTION
## 🔖 작업 내용 (Summary)
- api 명세에 맞게 목 데이터 타입 수정 d78b5936541605407ce9bbde05f3ac0408d56ba0
- storybook 컬러값 형식 변경 188a27e3e6393225b9bfda87ee5e56d84f33f8a3
- 버튼 컴포넌트에 outlined prop 추가 1166a0f4055f8892dd84a6fb9addbd28fcb0b654
- 선택된 날짜에 해당하는 하단 BlockList를 렌더링해야합니다. 이때 zustand를 사용하기 위해 store를 추가했습니다
f598f99513822516a7ec21b44a82d71c03feceeb 
=> WeeklyBlocks를 선택가능하도록 변경 b6680834a82bd9ed1f45e82cca15b7c78abb82b0

- 일기 작성 버튼(DiaryButton) 컴포넌트 추가 19877ef69fbc1ec48b88f94d6169a1ea715b4f62 

- 새 블럭 추가하기 버튼 클릭 시 /blocks/new 페이지로 연결 5192f8640391e8583b1ebecbc53c2de082a5281e

## 기타 사항 (Etc)

저번에 말씀드렸던 텍스트 인풋 관련해서는 조금 더 해보고 올릴게요!
그 외의 메인페이지 구성 작업하였습니다