### PR TITLE
feat: 웹뷰에서 RN으로 실행할 action 정의

### DIFF
--- a/src/components/Layout/Base.tsx
+++ b/src/components/Layout/Base.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react'
+
+export default function BaseLayout({ children }: PropsWithChildren) {
+  return <div className="inner">{children}</div>
+}

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,1 +1,2 @@
+export { default as BaseLayout } from './Base'
 export { default as BottomButtonLayout } from './BottomButton'

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,27 @@
-import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
+import Head from 'next/head'
 
 import msw from '@/mocks'
+import { BaseLayout } from '@/components/Layout'
+
+import '@/styles/globals.css'
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
   msw()
 }
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1, user-scalable=0"
+        />
+      </Head>
+      <BaseLayout>
+        <Component {...pageProps} />
+      </BaseLayout>
+    </>
+  )
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,12 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document'
 export default function Document() {
   return (
     <Html lang="en">
-      <Head>
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1, user-scalable=0"
-        />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />

--- a/src/utils/react-native-webview-bridge/WebBridge.ts
+++ b/src/utils/react-native-webview-bridge/WebBridge.ts
@@ -5,6 +5,7 @@ import {
   ECallbackMessageType,
   CallbackDataType,
   CallbackMessageData,
+  EMessageType,
 } from './types/common.type'
 
 export default class WebBridge {
@@ -12,6 +13,12 @@ export default class WebBridge {
    * @member eventList <이벤트키, 이벤트 전달 받을 시 실행할 콜백 함수>
    */
   protected static eventList = new Map<string, Callbacks>()
+
+  sendAction(action: string) {
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({ type: EMessageType.ACTION, action }),
+    )
+  }
 
   sendMessage(type: MessageType, data?: MessageData) {
     window.ReactNativeWebView.postMessage(JSON.stringify({ type, data }))

--- a/src/utils/react-native-webview-bridge/new-webview/index.ts
+++ b/src/utils/react-native-webview-bridge/new-webview/index.ts
@@ -14,8 +14,15 @@ function close(data: MessageData) {
   }
 }
 
+function sendAction(action: string) {
+  if (window?.ReactNativeWebView) {
+    webBridge.sendAction(action)
+  }
+}
+
 const RNNewWebView = {
   open,
   close,
+  sendAction,
 }
 export default RNNewWebView

--- a/src/utils/react-native-webview-bridge/new-webview/rnWebViewBridge.ts
+++ b/src/utils/react-native-webview-bridge/new-webview/rnWebViewBridge.ts
@@ -6,6 +6,7 @@ import { NewWebViewData } from '../types/newWebView.type'
 type ReturnType = {
   open: (data: NewWebViewData, callbacks?: RNCallBacks) => void
   close: () => void
+  sendAction: (action: string) => void
 }
 
 function rnWebViewBridge(): ReturnType {
@@ -26,7 +27,11 @@ function rnWebViewBridge(): ReturnType {
     RNNewWebView.close({ eventKey: thisKey })
   }
 
-  return { open, close }
+  const sendAction = (action: string) => {
+    RNNewWebView.sendAction(action)
+  }
+
+  return { open, close, sendAction }
 }
 
 export default rnWebViewBridge()

--- a/src/utils/react-native-webview-bridge/types/common.type.ts
+++ b/src/utils/react-native-webview-bridge/types/common.type.ts
@@ -6,12 +6,19 @@ export enum EMessageType {
   CLOSE_BOTTOM_SHEET = 'CLOSE_BOTTOM_SHEET',
   OPEN_NEW_WEBVIEW = 'OPEN_NEW_WEBVIEW',
   CLOSE_NEW_WEBVIEW = 'CLOSE_NEW_WEBVIEW',
+  ACTION = 'ACTION',
 }
 export type MessageType = keyof typeof EMessageType
 export type MessageData<T = Record<string | number, unknown>> = {
   eventKey: string
   contents?: T
 }
+
+export enum ACTION_TYPE {
+  GO_MAIN = 'GO_MAIN',
+  LOGOUT = 'LOGOUT',
+}
+export type ActionType = keyof typeof ACTION_TYPE
 
 /**
  * @description RN -> WebView 받을 수 있는 메세지 종류


### PR DESCRIPTION
## 🔖 작업 내용 (Summary)
* web에서 실행할 action 정의
* navigation, screen type 정의
* BaseLayout 생성하여 모든 페이지에 최대 너비 설정

파라미터가 필요 없이 action만 실행할 수 있습니다.
위키 문서에 정의된 액션 정리하겠습니다.
계속해서 추가할 예정입니다.

https://github.com/dnd-side-project/dnd-8th-7-frontend-app/wiki/App-Action

## 기타 사항 (Etc)
